### PR TITLE
Add puppet validation argument passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Provides the following hooks:
 3. Run `pre-commit install` to add pre-commit git hooks. You can also run
    `pre-commit run --all-files`, which is useful as part of your tests.
 
-Note that currently it's only possible to use the Puppet 3 parser for
-validation. The Puppet 4 parser has many changes, and it's planned to have a
-separate branch for Puppet 4 hooks in the future.
+To use the future parser with validation, just pass it as an argument
+to the `puppet-validate` hook:
+
+    -   id: puppet-validate
+        args: [--parser=future]
+
+This option will only work for Puppet 3. For Puppet 4, just use a
+updated version of `puppet` to run these hooks and remove the argument.
+
+Any other arguments to `puppet-validate` will be fed directly to
+`puppet parser validate`, as long as they are in the format `--arg=value`.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,5 @@ to the `puppet-validate` hook:
     -   id: puppet-validate
         args: [--parser=future]
 
-This option will only work for Puppet 3. For Puppet 4, just use a
-updated version of `puppet` to run these hooks and remove the argument.
-
 Any other arguments to `puppet-validate` will be fed directly to
 `puppet parser validate`, as long as they are in the format `--arg=value`.

--- a/bin/puppet-validate
+++ b/bin/puppet-validate
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 set -eu
 
+options=""
+opts_regex="^--.+=.+$"
+
 status=0
-for path in "$@"; do
-	output=$(puppet parser validate -- "$path" 2>&1) || {
-		echo -e "\033[31m\033[1m$path: failed Puppet validation\033[0m"
-		echo "$output"
-		status=1
-	}
+for arg in "$@"; do
+	# Check if the argument is a puppet validation option or a file
+	# The extra arguments always come first, so this will work fine
+	if [[ "$arg" =~ $opts_regex ]]; then
+		options="$options $arg"
+	else
+		output=$(puppet parser validate $options -- "$arg" 2>&1) || {
+			echo -e "\033[31m\033[1m$arg: failed Puppet validation\033[0m"
+			echo "$output"
+			status=1
+		}
+	fi
 done
 
 exit "$status"


### PR DESCRIPTION
This adds the ability to add arguments to the `puppet-validate` hook and have them passed to `puppet parser validate` when it runs, like `--parser=future` or `--ordering=random`, etc.

This is mostly only useful for the future parser though, since a lot of other puppet arguments aren't accepted by the validator.

Should this be in a separate branch? It doesn't break anything as-is, so I feel like it works ok without any changes, but the README originally said that Puppet 4 support would be in a separate branch.
