### PR TITLE
Don't pin Puppet via gemspec, instead use additional_dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,16 @@ to the `puppet-validate` hook:
 
 Any other arguments to `puppet-validate` will be fed directly to
 `puppet parser validate`, as long as they are in the format `--arg=value`.
+
+By default, the latest versions of `puppet` and `puppet-lint` are used. If
+you'd like to use a different version, you can pass `additional_dependencies`
+when definining the hooks, e.g.:
+
+```yaml
+hooks:
+-   id: puppet-validate
+    additional_dependencies: ['puppet:3.8.7']
+```
+
+To see what dependencies you might want to change, take a look at
+`hooks.yaml` in this repo.

--- a/__fake_gem.gemspec
+++ b/__fake_gem.gemspec
@@ -4,8 +4,6 @@ Gem::Specification.new do |s|
     s.authors = 'Chris Kuehl'
     s.summary = 'pre-commit hooks for Puppet projects'
     s.description = 'pre-commit hooks for Puppet projects'
-    s.add_dependency 'puppet-lint', '1.1.0'
-    s.add_dependency 'puppet', '3.8.1'
 
     s.bindir = 'ruby-stubs'
     s.executables = ['puppet-validate', 'erb-validate', 'epp-validate']

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -4,6 +4,7 @@
     entry: puppet-validate
     language: ruby
     files: \.pp$
+    additional_dependencies: ['puppet']
 
 -   id: erb-validate
     name: Validate ERB templates
@@ -18,6 +19,7 @@
     entry: epp-validate
     language: ruby
     files: \.epp$
+    additional_dependencies: ['puppet']
 
 -   id: puppet-lint
     name: puppet-lint
@@ -25,3 +27,4 @@
     entry: puppet-lint
     language: ruby
     files: \.pp$
+    additional_dependencies: ['puppet-lint']


### PR DESCRIPTION
Instead of pinning Puppet via gemspec, each hook specifies its dependencies. This is a bit nicer because it allows the consumers of these hooks to override `additional_dependencies` and request their own versions of `puppet` or `puppet-lint`.

By default the latest versions of each would be used.

@alexjurkiewicz @jvperrin thoughts?