### PR TITLE
fixes for latest gem

### DIFF
--- a/pre_commit_fake_gem.gemspec
+++ b/pre_commit_fake_gem.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-    s.name = '__fake_gem'
+    s.name = 'pre_commit_fake_gem'
     s.version = '0'
     s.authors = 'Chris Kuehl'
     s.summary = 'pre-commit hooks for Puppet projects'


### PR DESCRIPTION
```
invalid value for attribute name: "__fake_gem" can not begin with a period, dash, or underscore
```