### PR TITLE
Remove front anchor for Puppetfile

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,7 +16,7 @@
 - id: g10k-validate
   description: Validate syntax of Puppetfile using g10k
   entry: g10k-validate
-  files: ^Puppetfile$
+  files: Puppetfile$
   language: ruby
   name: Validate g10k Puppetfile
 
@@ -40,7 +40,7 @@
   additional_dependencies: ['r10k']
   description: Validate syntax of Puppetfile using r10k
   entry: r10k-validate
-  files: ^Puppetfile$
+  files: Puppetfile$
   language: ruby
   name: Validate r10k Puppetfile
 


### PR DESCRIPTION
This change allows (g|r)10k to find Puppetfiles that aren't in the root directory, for example a Puppetfile in a `vendor` directory.