### PR TITLE
Setting up a hook to manage puppet documentation

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -45,6 +45,14 @@
   language: ruby
   name: Validate Puppet manifests
 
+- id: puppet-strings
+  additional_dependencies: ['puppet-strings']
+  description: Validate puppet documentation is up to date
+  entry: puppet-strings
+  files: \.pp$
+  language: ruby
+  name: Validate puppet documentation
+
 - id: r10k-validate
   additional_dependencies: ['r10k']
   description: Validate syntax of Puppetfile using r10k

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Provides the following hooks:
 * **puppet-validate:** uses [`puppet parser validate`][puppet-parser] to check the syntax of
   Puppet manifests.
 
+* **puppet-strings:** uses [`puppet strings generate`][puppet-strings] to check the puppet documentation
+
 * **r10k-validate:** uses [r10k][r10k] to validate [Puppetfile][puppetfile] syntax.
 
 * **ruby-validate:** uses [`ruby -c`][ruby-c] to validate the syntax of ruby code.
@@ -30,6 +32,7 @@ Provides the following hooks:
 [g10k]: https://github.com/xorpaul/g10k
 [puppetfile]: https://puppet.com/docs/pe/latest/puppetfile.html
 [puppet-parser]: https://puppet.com/docs/puppet/latest/man/parser.html#EXAMPLES
+[puppet-strings]: https://puppet.com/docs/puppet/7/puppet_strings.html
 [r10k]: https://github.com/puppetlabs/r10k
 [rubocop]: https://github.com/rubocop-hq/rubocop
 [ruby-c]: https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/options.html
@@ -92,6 +95,9 @@ Provides the following hooks:
 
 Any other arguments to `puppet-validate` will be fed directly to
 `puppet parser validate`, as long as they are in the format `--arg=value`.
+
+Any other arguments to `puppet-strings` will be fed directly to
+`puppet strings generate`.
 
 By default, the latest versions of `puppet` and `puppet-lint` are used. If
 you'd like to use a different version, you can pass `additional_dependencies`

--- a/pre_commit_fake_gem.gemspec
+++ b/pre_commit_fake_gem.gemspec
@@ -6,5 +6,5 @@ Gem::Specification.new do |s|
     s.description = 'pre-commit hooks for Puppet projects'
 
     s.bindir = 'ruby-stubs'
-    s.executables = ['bolt-validate', 'erb-validate', 'epp-validate', 'g10k-validate', 'puppet-validate', 'r10k-validate', 'ruby-validate']
+    s.executables = ['bolt-validate', 'erb-validate', 'epp-validate', 'g10k-validate', 'puppet-validate', 'puppet-strings', 'r10k-validate', 'ruby-validate']
 end

--- a/ruby-stubs/puppet-strings
+++ b/ruby-stubs/puppet-strings
@@ -1,0 +1,21 @@
+require 'English'
+
+status = 0
+options = []
+ARGV.each do |arg|
+  # The following command will execute puppet strings to generate documentation
+  # As puppet strings does not return a non-zero rc when file changes
+  # We need to manually check it with a git command.
+  # The second part of the command will output the number of modified files
+  # outside the git stage zone for the doc folder (output folder of the 
+  # puppet strings command).
+  output = `puppet strings generate -- "#{arg}" 2>&1 && exit $(git status --porcelain doc | grep -v '^A' | wc -l)`
+  next if $CHILD_STATUS.exitstatus == 0
+  puts "#{arg}: failed Puppet validation"
+  puts output
+  status = 1
+end
+
+exit status
+
+# vim: ft=ruby


### PR DESCRIPTION
Hi,

Here is a small contribution to add a hook that manage puppet documentation with the help of the puppet strings command.

Signed-off-by: julien.girard <julien.girard@ovhcloud.com>